### PR TITLE
Dependencies fix for 2.7+ firmware

### DIFF
--- a/scripts/dependencies.sh
+++ b/scripts/dependencies.sh
@@ -9,18 +9,16 @@
 touch /tmp/SSLsplitNG.progress
 
 mkdir -p /tmp/SSLsplitNG
-wget https://github.com/adde88/openwrt-useful-tools/tree/packages-19.07 -P /tmp/SSLsplitNG
-SSLSPLIT=`grep -F "sslsplit_" /tmp/SSLsplitNG/packages-19.07 | awk {'print $5'} | awk -F'"' {'print $2'} | grep mips_24kc`
 
 cd /tmp
 opkg update
-wget "https://github.com/adde88/openwrt-useful-tools/raw/packages-19.07/"$SSLSPLIT""
+wget "https://github.com/adde88/openwrt-useful-tools/raw/packages-19.07_mkvi/sslsplit_0.5.5-3_mips_24kc.ipk" -P /tmp/SSLsplitNG
 
 if [ "$1" = "install" ]; then
   if [ "$2" = "internal" ]; then
-  	opkg install openssl-util libevent2-7 libevent2-core7 libevent2-extra7 libevent2-openssl7 libevent2-pthreads7 "$SSLSPLIT"
+  	opkg install openssl-util libevent2-7 libevent2-core7 libevent2-extra7 libevent2-openssl7 libevent2-pthreads7 libpcap /tmp/SSLsplitNG/sslsplit_0.5.5-3_mips_24kc.ipk
   elif [ "$2" = "sd" ]; then
-	opkg install openssl-util libevent2-7 libevent2-core7 libevent2-extra7 libevent2-openssl7 libevent2-pthreads7 "$SSLSPLIT" --dest sd
+	opkg install openssl-util libevent2-7 libevent2-core7 libevent2-extra7 libevent2-openssl7 libevent2-pthreads7 libpcap /tmp/SSLsplitNG/sslsplit_0.5.5-3_mips_24kc.ipk --dest sd
   fi
 
 	openssl genrsa -out /pineapple/modules/SSLsplitNG/cert/certificate.key 1024


### PR DESCRIPTION
Hello,

I've been trying to get SSLsplitNG working on the current version of WiFi Pineapple TETRA (2.7.0).
Stumbled across a few small dependency problems:

First one being that you've probably restructured your "openwrt-useful-tools" repo since the development of this script, which has resulted in inability to fetch the given SSLsplit version from it.

And the second one being the missing (outdated?) libpcap dependency:

LOG:
`Error loading shared library libpcap.so.0.8: No such file or directory (needed by /bin/sslsplit)
Error relocating /bin/sslsplit: pcap_dispatch: symbol not found
Error relocating /bin/sslsplit: pcap_close: symbol not found
Error relocating /bin/sslsplit: pcap_open_live: symbol not found
Error relocating /bin/sslsplit: pcap_geterr: symbol not found
Error relocating /bin/sslsplit: pcap_compile: symbol not found
Error relocating /bin/sslsplit: pcap_setfilter: symbol not found
Error relocating /bin/sslsplit: pcap_freecode: symbol not found
Error relocating /bin/sslsplit: pcap_lib_version: symbol not found`

Web search has shown that your version of SSLsplit is still used and these problems are relatively common.
This is a very dull way to fix them, though it does allow the module to be successfully installed and used.
If you would consider implementing these changes in a more suitable manner, feel free to deny the request.

Thanks for the development!